### PR TITLE
Add Novellus-themed Jira ticket creation app

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import os
+from datetime import datetime
+from typing import Dict
+
+from flask import Flask, jsonify, redirect, render_template, request, url_for, flash
+from requests import HTTPError
+
+from jira_client import JiraClient, JiraConfigurationError
+
+
+app = Flask(__name__)
+app.config["SECRET_KEY"] = os.environ.get("FLASK_SECRET_KEY", "change-me")
+
+
+def get_jira_client() -> JiraClient:
+    if not hasattr(app, "_jira_client"):
+        try:
+            app._jira_client = JiraClient()
+        except JiraConfigurationError as exc:  # type: ignore[attr-defined]
+            app._jira_client = exc
+    client = app._jira_client  # type: ignore[attr-defined]
+    if isinstance(client, JiraConfigurationError):
+        raise client
+    return client
+
+
+@app.route("/", methods=["GET"])
+def index():
+    error = None
+    try:
+        get_jira_client()
+    except JiraConfigurationError as exc:
+        error = str(exc)
+    return render_template("index.html", config_error=error)
+
+
+@app.route("/", methods=["POST"])
+def create_ticket():
+    summary = request.form.get("summary", "").strip()
+    details = request.form.get("details", "").strip()
+    start_date = request.form.get("start_date", "").strip()
+    due_date = request.form.get("due_date", "").strip()
+
+    missing = [label for label, value in (
+        ("Summary", summary),
+        ("Details", details),
+        ("Start Date", start_date),
+        ("Expected By Date", due_date),
+    ) if not value]
+
+    if missing:
+        flash(f"Please fill in the mandatory fields: {', '.join(missing)}", "error")
+        return redirect(url_for("index"))
+
+    # Validate ISO format (YYYY-MM-DD)
+    for label, value in (("Start Date", start_date), ("Expected By Date", due_date)):
+        try:
+            datetime.strptime(value, "%Y-%m-%d")
+        except ValueError:
+            flash(f"{label} must be in YYYY-MM-DD format.", "error")
+            return redirect(url_for("index"))
+
+    try:
+        client = get_jira_client()
+    except JiraConfigurationError as exc:
+        flash(str(exc), "error")
+        return redirect(url_for("index"))
+
+    try:
+        description = f"Details:\n{details}\n\nStart Date: {start_date}\nExpected By: {due_date}"
+        response = client.create_issue(summary, description, start_date, due_date)
+    except HTTPError as exc:
+        message = exc.response.json().get("errors") if exc.response else str(exc)
+        flash(f"Failed to create issue: {message}", "error")
+        return redirect(url_for("index"))
+
+    issue_key = response.get("key")
+    flash(f"Successfully created Jira issue {issue_key}.", "success")
+    return redirect(url_for("index"))
+
+
+@app.route("/api/issues/<issue_key>", methods=["GET", "PUT"])
+def issue_endpoint(issue_key: str):
+    try:
+        client = get_jira_client()
+    except JiraConfigurationError as exc:
+        return jsonify({"error": str(exc)}), 500
+
+    if request.method == "GET":
+        try:
+            issue = client.get_issue(issue_key)
+        except HTTPError as exc:
+            return jsonify({"error": str(exc), "details": exc.response.json() if exc.response else {}}), 400
+        return jsonify(issue)
+
+    payload: Dict[str, str] = request.json or {}
+    try:
+        result = client.update_issue(issue_key, payload.get("fields", payload))
+    except HTTPError as exc:
+        return (
+            jsonify({"error": str(exc), "details": exc.response.json() if exc.response else {}}),
+            exc.response.status_code if exc.response else 400,
+        )
+    return jsonify(result)
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=8505, debug=False)

--- a/config/jira_config.yml
+++ b/config/jira_config.yml
@@ -1,0 +1,7 @@
+jira:
+  base_url: "https://your-domain.atlassian.net"
+  email: "service-account@example.com"
+  api_token: "your_api_token"
+  project_key: "PROJ"
+  issue_type: "Task"
+  start_date_field_id: "customfield_10015"

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+python3 -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements.txt

--- a/jira_client.py
+++ b/jira_client.py
@@ -1,0 +1,112 @@
+"""Utility client for interacting with Jira's REST API."""
+from __future__ import annotations
+
+import base64
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+import requests
+import yaml
+
+logger = logging.getLogger(__name__)
+
+
+class JiraConfigurationError(RuntimeError):
+    """Raised when Jira configuration is missing required fields."""
+
+
+@dataclass
+class JiraSettings:
+    base_url: str
+    email: str
+    api_token: str
+    project_key: str
+    issue_type: str
+    start_date_field_id: Optional[str] = None
+
+    @property
+    def auth_header(self) -> str:
+        token = f"{self.email}:{self.api_token}".encode("utf-8")
+        return base64.b64encode(token).decode("utf-8")
+
+
+def load_settings(path: str = "config/jira_config.yml") -> JiraSettings:
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            content = yaml.safe_load(handle) or {}
+    except FileNotFoundError as exc:
+        raise JiraConfigurationError(
+            "Jira configuration file not found. Expected at config/jira_config.yml"
+        ) from exc
+
+    jira_config = content.get("jira") or {}
+    required = ["base_url", "email", "api_token", "project_key", "issue_type"]
+    missing = [field for field in required if not jira_config.get(field)]
+    if missing:
+        raise JiraConfigurationError(
+            f"Missing Jira configuration values: {', '.join(missing)}"
+        )
+
+    return JiraSettings(
+        base_url=jira_config["base_url"].rstrip("/"),
+        email=jira_config["email"],
+        api_token=jira_config["api_token"],
+        project_key=jira_config["project_key"],
+        issue_type=jira_config["issue_type"],
+        start_date_field_id=jira_config.get("start_date_field_id"),
+    )
+
+
+class JiraClient:
+    """Simple Jira client for creating and retrieving issues."""
+
+    def __init__(self, settings: Optional[JiraSettings] = None) -> None:
+        self.settings = settings or load_settings()
+        self.session = requests.Session()
+        self.session.headers.update(
+            {
+                "Accept": "application/json",
+                "Content-Type": "application/json",
+                "Authorization": f"Basic {self.settings.auth_header}",
+            }
+        )
+
+    def _url(self, path: str) -> str:
+        return f"{self.settings.base_url}{path}"
+
+    def create_issue(
+        self, summary: str, description: str, start_date: Optional[str], due_date: Optional[str]
+    ) -> Dict[str, Any]:
+        fields: Dict[str, Any] = {
+            "project": {"key": self.settings.project_key},
+            "summary": summary,
+            "issuetype": {"name": self.settings.issue_type},
+            "description": description,
+        }
+
+        if due_date:
+            fields["duedate"] = due_date
+
+        if start_date and self.settings.start_date_field_id:
+            fields[self.settings.start_date_field_id] = start_date
+        elif start_date:
+            # Store start date inside description when custom field is unavailable
+            fields["description"] = f"Start Date: {start_date}\n\n{description}"
+
+        payload = {"fields": fields}
+        response = self.session.post(self._url("/rest/api/3/issue"), json=payload, timeout=30)
+        response.raise_for_status()
+        return response.json()
+
+    def get_issue(self, issue_key: str) -> Dict[str, Any]:
+        response = self.session.get(self._url(f"/rest/api/3/issue/{issue_key}"), timeout=30)
+        response.raise_for_status()
+        return response.json()
+
+    def update_issue(self, issue_key: str, fields: Dict[str, Any]) -> Dict[str, Any]:
+        response = self.session.put(
+            self._url(f"/rest/api/3/issue/{issue_key}"), json={"fields": fields}, timeout=30
+        )
+        response.raise_for_status()
+        return response.json() if response.text else {"status": "success"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+Flask==2.3.3
+requests==2.31.0
+PyYAML==6.0.1
+python-dotenv==1.0.0

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+source .venv/bin/activate
+export FLASK_APP=app.py
+flask run --host=0.0.0.0 --port=8505

--- a/static/css/novellus.css
+++ b/static/css/novellus.css
@@ -1,0 +1,178 @@
+:root {
+  --novellus-bg: linear-gradient(135deg, #0f2027, #203a43, #2c5364);
+  --novellus-card-bg: rgba(255, 255, 255, 0.08);
+  --novellus-card-border: rgba(255, 255, 255, 0.25);
+  --novellus-text: #f4f9ff;
+  --novellus-accent: #50c9ce;
+  --novellus-accent-dark: #2b98a0;
+  --novellus-danger: #ff6b6b;
+  --novellus-success: #6fffc5;
+  --novellus-shadow: 0 25px 45px rgba(15, 32, 39, 0.35);
+  --novellus-radius: 18px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: "Poppins", sans-serif;
+  color: var(--novellus-text);
+  background: var(--novellus-bg);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 48px 16px;
+}
+
+.novellus-wrapper {
+  width: min(860px, 100%);
+  backdrop-filter: blur(20px);
+}
+
+.novellus-header,
+.novellus-footer {
+  text-align: center;
+  margin-bottom: 24px;
+}
+
+.novellus-header h1 {
+  margin: 0 0 12px;
+  font-size: 2.5rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.novellus-header p {
+  margin: 0;
+  font-weight: 300;
+  opacity: 0.8;
+}
+
+.novellus-card {
+  background: var(--novellus-card-bg);
+  border: 1px solid var(--novellus-card-border);
+  border-radius: var(--novellus-radius);
+  padding: 32px;
+  box-shadow: var(--novellus-shadow);
+  backdrop-filter: blur(35px);
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 20px;
+}
+
+.field label {
+  font-weight: 500;
+  margin-bottom: 8px;
+  letter-spacing: 0.03em;
+}
+
+.field input,
+.field textarea {
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  border-radius: 12px;
+  background: rgba(15, 32, 39, 0.5);
+  color: var(--novellus-text);
+  padding: 12px 16px;
+  font-size: 1rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.field input:focus,
+.field textarea:focus {
+  outline: none;
+  border-color: var(--novellus-accent);
+  box-shadow: 0 0 0 3px rgba(80, 201, 206, 0.25);
+}
+
+.field textarea {
+  resize: vertical;
+  min-height: 140px;
+}
+
+.field-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+
+.novellus-actions {
+  text-align: right;
+}
+
+.btn-primary {
+  background: linear-gradient(135deg, var(--novellus-accent), #74f2ce);
+  color: #0f2027;
+  border: none;
+  padding: 12px 28px;
+  font-size: 1rem;
+  font-weight: 600;
+  border-radius: 999px;
+  box-shadow: 0 16px 30px rgba(80, 201, 206, 0.35);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.btn-primary:hover,
+.btn-primary:focus {
+  transform: translateY(-1px);
+  box-shadow: 0 20px 35px rgba(80, 201, 206, 0.45);
+  outline: none;
+}
+
+.novellus-footer {
+  font-size: 0.9rem;
+  opacity: 0.8;
+}
+
+.novellus-footer code {
+  background: rgba(15, 32, 39, 0.6);
+  padding: 4px 8px;
+  border-radius: 8px;
+}
+
+.novellus-alert-list {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 16px;
+  display: grid;
+  gap: 12px;
+}
+
+.novellus-alert {
+  padding: 14px 18px;
+  border-radius: 14px;
+  font-weight: 500;
+  backdrop-filter: blur(18px);
+}
+
+.novellus-alert.success {
+  background: rgba(111, 255, 197, 0.15);
+  border: 1px solid rgba(111, 255, 197, 0.45);
+  color: var(--novellus-text);
+}
+
+.novellus-alert.error {
+  background: rgba(255, 107, 107, 0.18);
+  border: 1px solid rgba(255, 107, 107, 0.5);
+  color: var(--novellus-text);
+}
+
+@media (max-width: 600px) {
+  body {
+    padding: 24px 12px;
+  }
+
+  .novellus-card {
+    padding: 24px;
+  }
+
+  .novellus-header h1 {
+    font-size: 2rem;
+  }
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Novellus Jira Ticket Creator</title>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;500;600&display=swap" />
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/novellus.css') }}" />
+  </head>
+  <body>
+    <div class="novellus-wrapper">
+      <header class="novellus-header">
+        <h1>Novellus Jira Ticket Creator</h1>
+        <p>Create tickets without exposing your Jira credentials.</p>
+      </header>
+
+      {% if config_error %}
+        <div class="novellus-alert error">{{ config_error }}</div>
+      {% endif %}
+
+      {% with messages = get_flashed_messages(with_categories=true) %}
+        {% if messages %}
+          <ul class="novellus-alert-list">
+            {% for category, message in messages %}
+              <li class="novellus-alert {{ category }}">{{ message }}</li>
+            {% endfor %}
+          </ul>
+        {% endif %}
+      {% endwith %}
+
+      <section class="novellus-card">
+        <form method="post" novalidate>
+          <div class="field">
+            <label for="summary">Summary</label>
+            <input type="text" id="summary" name="summary" placeholder="Short description of the issue" required />
+          </div>
+          <div class="field">
+            <label for="details">Details</label>
+            <textarea id="details" name="details" rows="5" placeholder="Full details of the request" required></textarea>
+          </div>
+          <div class="field-row">
+            <div class="field">
+              <label for="start_date">Start Date</label>
+              <input type="date" id="start_date" name="start_date" required />
+            </div>
+            <div class="field">
+              <label for="due_date">Expected by Date</label>
+              <input type="date" id="due_date" name="due_date" required />
+            </div>
+          </div>
+          <div class="novellus-actions">
+            <button type="submit" class="btn-primary">Create Ticket</button>
+          </div>
+        </form>
+      </section>
+
+      <footer class="novellus-footer">
+        <p>
+          Configure the Jira connection in <code>config/jira_config.yml</code>. This application uses
+          a service account to create issues through the Jira REST API.
+        </p>
+      </footer>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a Flask application with Novellus themed UI for creating Jira tickets using REST APIs
- implement a reusable Jira client that reads service account credentials from config/jira_config.yml
- provide project setup scripts and configuration for running the app on port 8505

## Testing
- python -m compileall app.py jira_client.py

------
https://chatgpt.com/codex/tasks/task_e_68dc08ac3338832081897d38643e1f3a